### PR TITLE
Fixed guest name synchronization with OzLocks

### DIFF
--- a/src/SyncHms.Services/Services/Implement/OperaService.cs
+++ b/src/SyncHms.Services/Services/Implement/OperaService.cs
@@ -365,9 +365,9 @@ internal class OperaService(IControl<OperaOptions, ApplicationEnvironment> contr
                                     {
                                         ReservationId = rn.ResvNameId ?? default,
                                         rn.ConfirmationNo,
-                                        FirstName = Trim(n.XfirstName ?? n.First ?? string.Empty),
-                                        LastName = Trim(n.XlastName ?? n.Last ?? string.Empty),
-                                        MiddleName = Trim(n.XmiddleName ?? n.Middle ?? string.Empty),
+                                        FirstName = Trim(n.XfirstName ?? n.First) ?? string.Empty,
+                                        LastName = Trim(n.XlastName ?? n.Last) ?? string.Empty,
+                                        MiddleName = Trim(n.XmiddleName ?? n.Middle) ?? string.Empty,
                                         Sex = n.Gender,
                                         Status = rn.ResvStatus,
                                         rde.Room,


### PR DESCRIPTION
# Bugs fixed
- [Fixed transmission of NULL field values LastName, FirstName and MiddleName](https://github.com/ivankopanyov/SyncHms/commit/b8492759fe8f2facf5bef906f7705bb1bc4adeaa) 